### PR TITLE
fix: clarify the requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A python-based card generation script that allows users to generate Enka.Network
 
 ## Initial Setup
 
+This project requires `python` is 3.9 or later.
 Install the required dependencies:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ uid = 604905943 # <- Change this to your UID
 
 async def main():
     async with client:
-        data = await client.fetch_user(uid)
+        data = await client.fetch_user_by_uid(uid)
         for character in data.characters:
             print(f"[{uid}] Generating enka-card for {character.name}")
             generate_image(data, character, client.lang)

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ uid = 604905943
 
 async def main():
     async with client:
-        data = await client.fetch_user(uid)
+        data = await client.fetch_user_by_uid(uid)
         for character in data.characters:
             print(f"[{uid}] Generating enka-card for {character.name}")
             generate_image(data, character, client.lang)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-enkanetwork.py
+enkanetwork.py>=1.4.0
 pillow
 pydantic<2
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 enkanetwork.py
 pillow
-pydantic
+pydantic<2
 requests


### PR DESCRIPTION
Hi, I tried to run this project recently and found that the requirements may need to be changed in order to run properly. I made some modifications to make the code up-to-date.

- `pydantic` should be smaller than 2 currently which is not resolved by the upstream:  https://github.com/mrwan200/EnkaNetwork.py/issues/48
- `fetch_user(uid)` will be deprecated soon, use `fetch_user_by_uid(uid)` instead. See [README description](https://github.com/mrwan200/EnkaNetwork.py/blob/c671d32bebaccefa54bbb975c0b4602271ea4389/README.md?plain=1#L93) which is introduced in https://github.com/mrwan200/EnkaNetwork.py/pull/28.
- The use of the annotation like `dict[str, int]` requires `python>=3.9`. See [What’s New In Python 3.9](https://docs.python.org/release/3.9.0/whatsnew/3.9.html#type-hinting-generics-in-standard-collections).